### PR TITLE
feature: store api url in local storage settings

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -2,6 +2,7 @@ import { createChromeStorageStateHookLocal } from 'use-chrome-storage';
 export const SETTINGS_KEY = 'settings';
 export const INITIAL_VALUE = {
   apiKey: '',
+  baseUrl: process.env.AI_BASE_URL,
 };
 
 export const useSettingsStore = createChromeStorageStateHookLocal(

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -68,7 +68,7 @@ class PpdnsBackground {
       return;
     }
 
-    let baseUrl = process.env.AI_BASE_URL;
+    let baseUrl = global.AI_BASE_URL_OVERRIDE || process.env.AI_BASE_URL;
     let headers = {
       // todo grab from settings!
       Authorization: apiKey,

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -68,7 +68,7 @@ class PpdnsBackground {
       return;
     }
 
-    let baseUrl = global.AI_BASE_URL_OVERRIDE || process.env.AI_BASE_URL;
+    let baseUrl = result.settings.baseUrl || process.env.AI_BASE_URL;
     let headers = {
       // todo grab from settings!
       Authorization: apiKey,


### PR DESCRIPTION
these changes should allow a dev to change the URL the extension submits to by running this in the dev console of the service worker.  This would remain until the local storage is cleared.

```javascript
chrome.storage.local.get('settings').then((r) =>
    chrome.storage.local.set(
        {'settings': {...r.settings, baseUrl: 'https://api.stage-new.polyswarm.network'}}
    )
)

```