### PR TITLE
DN-5545 fix: remove beta

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# PolySwarm NectarNet Beta Browser Extension
+# PolySwarm NectarNet Browser Extension
 
-This repository is the source tree for the PolySwarm browser extension for the NectarNet Beta Program.
+This repository is the source tree for the PolySwarm browser extension for the NectarNet Program.
 If you want to help us improve this browser extension, follow the guidance in this document.
 
 # Chrome Extension Development
@@ -10,16 +10,10 @@ Our Chrome extension based off this
 
 ## General
 
-All development is done with Webstorm.
-
-* [Getting Started Guide](https://developer.chrome.com/docs/extensions/mv3/getstarted/)
-* [Webstorm](https://stackoverflow.com/questions/13997468/how-do-i-use-webstorm-for-chrome-extension-development) support for
-code completion on chrome variable will be helpful in extension development.
-
+- [Getting Started Guide](https://developer.chrome.com/docs/extensions/mv3/getstarted/)
 
 ## Getting Running
 
-Run configs are available in `webstorm/runconfigs`.
 See the original boilerplate's [README.md](https://github.com/lxieyang/chrome-extension-boilerplate-react/blob/master/README.md#procedures) for instructions on how to
 use `npm start` and load a development version of the extension in your local chrome browser from
 the `build` folder.
@@ -68,7 +62,6 @@ Anytime a new version is to be released, make sure to update the following:
 1. The [Rewards](https://docs.polyswarm.io/consumers/rewards/#browser-extension) page in the PolySwarm docs.
 2. The `README.md` file in this repository.
 
-
 # Safari Extension Development
 
 COMING SOON...
@@ -76,4 +69,4 @@ COMING SOON...
 # Other Notes
 
 Our Google analytics indicate that 95% of our browser traffic to `.io` and `.network` is
-from Chrome & Safari. Therefore, we'll ignore Firefox for the moment.
+from Chrome & Safari.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A browser extension intended to collect and send security relevant data to PolyS
 3. Open Chrome and go to `chrome://extensions/`
 4. Check `Developer mode`
 5. Click on `Load unpacked extension`
-6. Select the `ppdns-chrome-extension-v1.0.10` folder that you unzipped.
+6. Select the `ppdns-chrome-extension-v1.1.2` folder that you unzipped.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# NectarNet Beta Chrome Extension
+# NectarNet Chrome Extension
 
 A browser extension intended to collect and send security relevant data to PolySwarm, in exchange for distributing rewards in the form of [NCT](https://polyswarm.io/aboutnct) tokens.
 
 ## Requirements
 
 - Chrome, Brave, or Firefox browser
-- The latest version of the NectarNet Beta Browser Extension
+- The latest version of the NectarNet Browser Extension
 
 ## Installation
 
@@ -21,7 +21,7 @@ A browser extension intended to collect and send security relevant data to PolyS
 
 ### Manual
 
-1. Download the [NectarNet Beta Browser Extension](https://github.com/polyswarm/ppdns-chrome-extension/releases/download/v1.0.10/ppdns-chrome-extension-v1.0.10.zip) .zip file.
+1. Download the [NectarNet Browser Extension](https://github.com/polyswarm/ppdns-chrome-extension/releases/download/v1.0.10/ppdns-chrome-extension-v1.0.10.zip) .zip file.
 2. Double-click the `ppdns-chrome-extension-v1.0.10-zip` file to unzip it.
 3. Open Chrome and go to `chrome://extensions/`
 4. Check `Developer mode`
@@ -34,7 +34,7 @@ A browser extension intended to collect and send security relevant data to PolyS
 2. Log in or Sign up
 3. Navigate to Settings -> Rewards
 4. Review and accept the Terms and Privacy Policy
-5. Click the "Join the Beta" button.
+5. Click the "Join" button.
 6. Navigate to [Settings -> API Keys](https://docs.polyswarm.io/consumers/accounts#api-keys)
 7. Copy your API key to the clipboard.
 8. Open the Extensions dropdown and click the `ppdns` extension.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A browser extension intended to collect and send security relevant data to PolyS
 
 ### Manual
 
-1. Download the [NectarNet Browser Extension](https://github.com/polyswarm/ppdns-chrome-extension/releases/download/v1.0.10/ppdns-chrome-extension-v1.0.10.zip) .zip file.
+1. Download the [NectarNet Browser Extension](https://github.com/polyswarm/ppdns-chrome-extension/releases/download/v1.1.2/ppdns-chrome-extension-v1.1.2.zip) .zip file.
 2. Double-click the `ppdns-chrome-extension-v1.0.10-zip` file to unzip it.
 3. Open Chrome and go to `chrome://extensions/`
 4. Check `Developer mode`

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A browser extension intended to collect and send security relevant data to PolyS
 ### Manual
 
 1. Download the [NectarNet Browser Extension](https://github.com/polyswarm/ppdns-chrome-extension/releases/download/v1.1.2/ppdns-chrome-extension-v1.1.2.zip) .zip file.
-2. Double-click the `ppdns-chrome-extension-v1.0.10-zip` file to unzip it.
+2. Double-click the `ppdns-chrome-extension-v1.1.2.zip` file to unzip it.
 3. Open Chrome and go to `chrome://extensions/`
 4. Check `Developer mode`
 5. Click on `Load unpacked extension`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ppdns-chrome-extension",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppdns-chrome-extension",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "",
   "license": "MIT",
   "repository": {

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -126,8 +126,7 @@ class PpdnsBackground {
       type: 'basic',
       iconUrl: 'icon-34.png',
       title: 'Error submitting data',
-      message:
-        'There was an issue submitting data.  Read the docs: https://docs.polyswarm.io/consumers/rewards/#rewards',
+      message: 'There was an issue submitting data.',
       priority: 2,
     });
   }

--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -72,12 +72,12 @@ const Popup = () => {
             settings.apiKey.length &&
             settings.ingestSuccess == 'false' && (
               <div className="ingest-failure">
-                There was an issue submitting data. Have you joined the beta?{' '}
+                There was an issue submitting data. Have you joined the{' '}
                 <a
                   target="_blank"
-                  href="https://docs.polyswarm.io/consumers/rewards/#rewards"
+                  href="https://polyswarm.network/account/rewards"
                 >
-                  Read the docs.
+                  NectarNet program?
                 </a>
               </div>
             )}


### PR DESCRIPTION
https://polyswarm.atlassian.net/browse/DN-5545

1. Remove the word `Beta` from the readme, etc
2. Remove some webstorm and firefox references from the readme, as they are not relevant.
3. Update the error messages to remove `Beta`
4. Update the link in ingest error message, change from docs to the rewards tab of the account. 