### PR TITLE
[5624] Reproductible builds on CI, targeting Stage environment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,29 +73,3 @@ build-prod:
   environment:
     POLYSWARM_API_URL=https://api.polyswarm.network
     NODE_ENV=production
-
-
-###############################################################
-# End-to-end Stage
-###############################################################
-
-# e2e:
-#   stage: e2e
-#   tags:
-#     - kube-new
-#   script:
-#     - e2e run
-
-###############################################################
-# Release Stage
-###############################################################
-
-# release:
-#   stage: release
-#   tags:
-#     - kube-small-new
-#   script:
-#     - docker manifest create $REPO_URL/$BASE_IMAGE_NAME:latest $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
-#     - docker manifest push $REPO_URL/$BASE_IMAGE_NAME:latest
-#   only:
-#     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,13 +5,13 @@ services:
 
 stages:
   - build
-  - test
-  - e2e
-  - release
-  - deployment
+  # - test
+  # - e2e
+  # - release
+  # - deployment
 
 variables:
-  BASE_IMAGE_NAME: portal-frontend
+  BASE_IMAGE_NAME: ppdns-extensions
   DOCKER_HOST: tcp://localhost:2376
   DOCKER_TLS_CERTDIR: "/certs"
   DOCKER_TLS_VERIFY: 1
@@ -76,23 +76,23 @@ build-prod:
 # End-to-end Stage
 ###############################################################
 
-e2e:
-  stage: e2e
-  tags:
-    - kube-new
-  script:
-    - e2e run
+# e2e:
+#   stage: e2e
+#   tags:
+#     - kube-new
+#   script:
+#     - e2e run
 
 ###############################################################
 # Release Stage
 ###############################################################
 
-release:
-  stage: release
-  tags:
-    - kube-small-new
-  script:
-    - docker manifest create $REPO_URL/$BASE_IMAGE_NAME:latest $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
-    - docker manifest push $REPO_URL/$BASE_IMAGE_NAME:latest
-  only:
-    - master
+# release:
+#   stage: release
+#   tags:
+#     - kube-small-new
+#   script:
+#     - docker manifest create $REPO_URL/$BASE_IMAGE_NAME:latest $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
+#     - docker manifest push $REPO_URL/$BASE_IMAGE_NAME:latest
+#   only:
+#     - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,98 @@
+image: $REPO_URL/stage
+
+services:
+  - $REPO_URL/public/docker/library/docker:dind
+
+stages:
+  - build
+  - test
+  - e2e
+  - release
+  - deployment
+
+variables:
+  BASE_IMAGE_NAME: portal-frontend
+  DOCKER_HOST: tcp://localhost:2376
+  DOCKER_TLS_CERTDIR: "/certs"
+  DOCKER_TLS_VERIFY: 1
+  DOCKER_CERT_PATH: "$DOCKER_TLS_CERTDIR/client"
+
+default:
+  before_script:
+    - pip install $END_TO_END_LIB@$CI_COMMIT_REF_NAME || pip install $END_TO_END_LIB
+    - e2e init
+
+###############################################################
+# Build Stage (jobs inside a stage run in parallel)
+###############################################################
+
+.BUILD:
+  stage: build
+  tags:
+    - kube-new
+  script:
+    # try to download the multi-stage dependant image and retag it as latest
+    - e2e dependencies docker/Dockerfile
+    - docker buildx build
+      -f docker/Dockerfile
+      -t $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
+      -t $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_REF_SLUG
+      --cache-from=$REPO_URL/$BASE_IMAGE_NAME:latest
+      .
+    - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
+    - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_REF_SLUG
+
+  artifacts:
+    name: "extensions-$CI_JOB_NAME-$CI_COMMIT_SHA.zip"
+    paths:
+    - "dist/*.zip"
+    expire_in: 1 week
+
+
+build-local:
+  extends: .BUILD
+  environment:
+    POLYSWARM_API_URL=http://artifact-index-e2e:9696
+    BATCH_SIZE=3
+    NODE_ENV=development
+
+
+build-stage:
+  extends: .BUILD
+  environment:
+    POLYSWARM_API_URL=https://api.stage-v3.polyswarm.network
+    BATCH_SIZE=10
+    NODE_ENV=production
+
+
+build-prod:
+  extends: .BUILD
+  environment:
+    POLYSWARM_API_URL=https://api.polyswarm.network
+    NODE_ENV=production
+
+
+###############################################################
+# End-to-end Stage
+###############################################################
+
+e2e:
+  stage: e2e
+  tags:
+    - kube-new
+  script:
+    - e2e run
+
+###############################################################
+# Release Stage
+###############################################################
+
+release:
+  stage: release
+  tags:
+    - kube-small-new
+  script:
+    - docker manifest create $REPO_URL/$BASE_IMAGE_NAME:latest $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
+    - docker manifest push $REPO_URL/$BASE_IMAGE_NAME:latest
+  only:
+    - master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,6 +41,9 @@ default:
       .
     - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
     - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_REF_SLUG
+    - docker run -e POLYSWARM_API_URL -e BATCH_SIZE -e APPLICATION=build \
+      -v $PWD/dist:/usr/src/app/dist:rw \
+      -t $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
 
   artifacts:
     name: "extensions-$CI_JOB_NAME-$CI_COMMIT_SHA.zip"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+browser-extensions:
+	npm run build
+
+check-apikey:
+		curl 'http://artifact-index-e2e:9696//v2/instance' \
+		  -H 'authority: api.stage-new.polyswarm.network' \
+		  -H 'accept: */*' \
+		  -H 'accept-language: pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7' \
+		  -H 'authorization: 11111111111111111111111111111111' \
+		  -H 'sec-ch-ua: "Chromium";v="104", " Not A;Brand";v="99", "Google Chrome";v="104"' \
+		  -H 'sec-ch-ua-mobile: ?0' \
+		  -H 'sec-ch-ua-platform: "Linux"' \
+		  -H 'sec-fetch-dest: empty' \
+		  -H 'sec-fetch-mode: cors' \
+		  -H 'sec-fetch-site: none' \
+		  -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.79 Safari/537.36' \
+		  --compressed ;
+
+produce-telemetry:
+		curl 'http://artifact-index-e2e:9696//v3/telemetry/' \
+          -H 'authority: api.stage-new.polyswarm.network' \
+          -H 'accept: */*' \
+          -H 'accept-language: pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7' \
+          -H 'authorization: 11111111111111111111111111111111' \
+          -H 'content-type: application/json' \
+          -H 'origin: chrome-extension://hagikoogphpeogkjbillinmoaephfddg' \
+          -H 'sec-fetch-dest: empty' \
+          -H 'sec-fetch-mode: cors' \
+          -H 'sec-fetch-site: none' \
+          -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.79 Safari/537.36' \
+          --data-raw '{"resolutions":[{"type":"Resolution","attributes":{"host_name":"pudim.com.br","ip_address":"54.207.20.104"}}]}' \
+          --compressed ;
+

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ browser-extensions:
 	npm run build
 
 check-apikey:
-		curl 'http://artifact-index-e2e:9696//v2/instance' \
+		curl '$POLYSWARM_API_URL/v2/instance' \
 		  -H 'authority: api.stage-new.polyswarm.network' \
 		  -H 'accept: */*' \
 		  -H 'accept-language: pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7' \
@@ -17,7 +17,7 @@ check-apikey:
 		  --compressed ;
 
 produce-telemetry:
-		curl 'http://artifact-index-e2e:9696//v3/telemetry/' \
+		curl '$POLYSWARM_API_URL/v3/telemetry/' \
           -H 'authority: api.stage-new.polyswarm.network' \
           -H 'accept: */*' \
           -H 'accept-language: pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7' \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ browser-extensions:
 
 check-apikey:
 		curl '$POLYSWARM_API_URL/v2/instance' \
-		  -H 'authority: api.stage-new.polyswarm.network' \
+		  -H 'authority: $POLYSWARM_API_URL' \
 		  -H 'accept: */*' \
 		  -H 'accept-language: pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7' \
 		  -H 'authorization: 11111111111111111111111111111111' \
@@ -18,7 +18,7 @@ check-apikey:
 
 produce-telemetry:
 		curl '$POLYSWARM_API_URL/v3/telemetry/' \
-          -H 'authority: api.stage-new.polyswarm.network' \
+          -H 'authority: $POLYSWARM_API_URL' \
           -H 'accept: */*' \
           -H 'accept-language: pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7' \
           -H 'authorization: 11111111111111111111111111111111' \
@@ -30,4 +30,3 @@ produce-telemetry:
           -H 'user-agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.5112.79 Safari/537.36' \
           --data-raw '{"resolutions":[{"type":"Resolution","attributes":{"host_name":"pudim.com.br","ip_address":"54.207.20.104"}}]}' \
           --compressed ;
-

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ check-apikey:
 		  --compressed ;
 
 produce-telemetry:
-		curl '$POLYSWARM_API_URL/v3/telemetry/' \
-          -H 'authority: $POLYSWARM_API_URL' \
+		curl "${POLYSWARM_API_URL}/v3/telemetry/" \
+          -H "authority: ${POLYSWARM_API_URL}" \
           -H 'accept: */*' \
           -H 'accept-language: pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7' \
           -H 'authorization: 11111111111111111111111111111111' \

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ browser-extensions:
 	npm run build
 
 check-apikey:
-		curl '$POLYSWARM_API_URL/v2/instance' \
-		  -H 'authority: $POLYSWARM_API_URL' \
+		curl "${POLYSWARM_API_URL}/v2/instance" \
+		  -H "authority: ${POLYSWARM_API_URL}" \
 		  -H 'accept: */*' \
 		  -H 'accept-language: pt-BR,pt;q=0.9,en-US;q=0.8,en;q=0.7' \
 		  -H 'authorization: 11111111111111111111111111111111' \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV REACT_APP_URL=http://portal-frontend-e2e:8080 \
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.17/main" >> /etc/apk/repositories \
   && apk upgrade -U -a \
-  && apk add --no-cache chromium ffmpeg curl \
+  && apk add --no-cache chromium curl \
   && apk add --no-cache build-base bash \
   && apk add --no-cache python3 py3-pip
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,39 @@
+FROM 005789955001.dkr.ecr.us-east-2.amazonaws.com/public/docker/library/node:18.18-alpine3.17
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# REACT_* variables need to be available at build time
+ENV REACT_APP_URL=http://portal-frontend-e2e:8080 \
+  REACT_APP_API_URL=http://portal-backend-e2e:3000/api \
+  REACT_APP_AUTH0_URL=https://auth0-e2e:8081 \
+  REACT_APP_AUTH0_CLIENT_ID=ZefKD4c7JGZaxAHMFKjqgjaUG9tI3Glv \
+  REACT_APP_AUTH0_AUDIENCE=https://portal-api \
+  REACT_APP_GA_ID=UA-142135442-2 \
+  CHROMIUM_BIN=/usr/bin/chromium-browser
+
+RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.17/main" >> /etc/apk/repositories \
+  && apk upgrade -U -a \
+  && apk add --no-cache chromium ffmpeg curl \
+  && apk add --no-cache build-base bash \
+  && apk add --no-cache python3 py3-pip
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm install
+
+RUN mkdir -p test-results
+
+# Build
+COPY tsconfig.json ./
+COPY ./src ./src
+
+# Copy files
+COPY . .
+
+# Run
+EXPOSE 8080
+
+RUN make browser-extensions
+
+CMD ["./docker/run.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,6 +34,5 @@ COPY . .
 # Run
 EXPOSE 8080
 
-RUN make browser-extensions
-
+ENTRYPOINT ["/bin/bash", "-c"]
 CMD ["./docker/run.sh"]

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+set -ex
+
+APPLICATION=${APPLICATION:-web}
+PORT=${PORT}
+
+if [ "$APPLICATION" == "web" ] && [ -z "$PORT" ]; then
+  echo "The environment variable PORT must be provided." && exit 1
+fi
+
+case "$APPLICATION" in
+  web) exec yarn serve -p $PORT ;;
+  build) exec make browser-extensions ;;
+  test) exec yarn test:ci ;;
+  debug) exec sleep infinity ;;
+  *) echo "The environment variable APPLICATION must be provided." && exit 1 ;;
+esac

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-APPLICATION=${APPLICATION:-web}
+APPLICATION=${APPLICATION:-build}
 PORT=${PORT}
 
 if [ "$APPLICATION" == "web" ] && [ -z "$PORT" ]; then
@@ -10,7 +10,7 @@ if [ "$APPLICATION" == "web" ] && [ -z "$PORT" ]; then
 fi
 
 case "$APPLICATION" in
-  web) exec yarn serve -p $PORT ;;
+  web) exec npm run start -p $PORT ;;
   build) exec make browser-extensions ;;
   test) exec yarn test:ci ;;
   debug) exec sleep infinity ;;

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -22,7 +22,7 @@ class PpdnsBackground {
         console.debug('Not in a Chrome-ish browser, or something changed.');
       }
 
-      if (!this.version){
+      if (!this.version) {
         try {
           console.debug('Assuming to be running in a Firefox browser.');
           this.version = (await browser.management.getSelf()).version;

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -7,6 +7,34 @@ class PpdnsBackground {
     this.ppdnsBatchSize = parseInt(process.env.BATCH_SIZE);
     this.submitInProgress = false;
     this.debouncedSubmitPpdnsBatch = debounce(this.submitPpdnsBatch, 500);
+    this.version = null;
+    this.getVersion().finally(() => {
+      console.info('Extension version detected: ' + this.version);
+    });
+  }
+
+  async getVersion() {
+    if (!this.version) {
+      try {
+        console.debug('Assuming to be running in a Chrome-ish browser.');
+        this.version = (await chrome.management.getSelf()).version;
+      } catch (error) {
+        console.debug('Not in a Chrome-ish browser, or something changed.');
+      }
+
+      if (!this.version){
+        try {
+          console.debug('Assuming to be running in a Firefox browser.');
+          this.version = (await browser.management.getSelf()).version;
+        } catch (error) {
+          console.debug('Not in a Firefox browser, or something changed.');
+          console.info('Letting the version unknown');
+          this.version = '(unknown)';
+        }
+      }
+    }
+
+    return this.version;
   }
 
   logPpdnsRequest(webRequestBody) {
@@ -62,6 +90,7 @@ class PpdnsBackground {
     this.ppdnsL.clear();
     let data = {
       resolutions: Array.from(toSubmit.values()),
+      sender_version: this.version,
     };
     if (
       typeof result.settings === 'undefined' ||

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -107,7 +107,7 @@ var options = {
   },
   plugins: [
     new ZipPlugin({
-      path: '../',
+      path: '../dist/',
       filename: `ppdns-chrome-extension-v${process.env.npm_package_version}.zip`,
     }),
     new CleanWebpackPlugin({ verbose: false }),

--- a/webpack.ff.config.js
+++ b/webpack.ff.config.js
@@ -107,7 +107,7 @@ var options = {
   },
   plugins: [
     new ZipPlugin({
-      path: '../',
+      path: '../dist/',
       filename: `ppdns-firefox-extension-v${process.env.npm_package_version}.zip`,
     }),
     new CleanWebpackPlugin({ verbose: false }),


### PR DESCRIPTION
This makes ppdns-chrome-extension able to produce artifacts in a reproducible manner, inside the CI.

Also stores the artifacts produced via Gitlab CI "Artifacts", expiring in 1 week.

Some stuff may be able to be skimmed further, but for now, imho this will do.