### PR TITLE
[5699] better error messages

### DIFF
--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -22,8 +22,11 @@ export const initStorage = async (storage) => {
 };
 
 export const updateStorageField = async (storage, key, field, value) => {
+  console.debug('Updating the local storage with: %s.%s = %s', key, field, value);
+
   let storage_map = await storage.get(key);
   if (Object.keys(storage_map).length == 0){
+    console.info('Storage key "%s" found empty. Initializing with default data', key);
     await initStorage(storage);
     storage_map = await storage.get(key);
   }

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -13,16 +13,20 @@ export const useSettingsStore = createChromeStorageStateHookLocal(
   INITIAL_VALUE
 );
 
-export const initStorage = (storage) => {
-  if (!!storage.get(SETTINGS_KEY)){
+export const initStorage = async (storage) => {
+  if (Object.keys(await storage.get(SETTINGS_KEY).length == 0)){
     let storage_map = {};
     storage_map[SETTINGS_KEY] = INITIAL_VALUE;
-    storage.set(storage_map);
+    await storage.set(storage_map);
   }
 };
 
 export const updateStorageField = async (storage, key, field, value) => {
   let storage_map = await storage.get(key);
+  if (Object.keys(storage_map).length == 0){
+    await initStorage(storage);
+    storage_map = await storage.get(key);
+  }
   storage_map[key][field] = value;
   return await storage.set(storage_map)
 };

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -5,6 +5,7 @@ export const INITIAL_VALUE = {
   ingestSuccess: '',
   resolutionsSubmittedCount: '0',
   baseUrl: process.env.POLYSWARM_API_URL,
+  snoozedUntil: '0',
 };
 
 export const useSettingsStore = createChromeStorageStateHookLocal(
@@ -18,4 +19,10 @@ export const initStorage = (storage) => {
     storage_map[SETTINGS_KEY] = INITIAL_VALUE;
     storage.set(storage_map);
   }
+};
+
+export const updateStorageField = async (storage, key, field, value) => {
+  let storage_map = await storage.get(key);
+  storage_map[key][field] = value;
+  return await storage.set(storage_map)
 };

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -11,3 +11,11 @@ export const useSettingsStore = createChromeStorageStateHookLocal(
   SETTINGS_KEY,
   INITIAL_VALUE
 );
+
+export const initStorage = (storage) => {
+  if (!!storage.get(SETTINGS_KEY)){
+    let storage_map = {};
+    storage_map[SETTINGS_KEY] = INITIAL_VALUE;
+    storage.set(storage_map);
+  }
+};

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -1,5 +1,6 @@
 import debounce from 'lodash.debounce';
-import { SETTINGS_KEY } from '../../common/settings';
+import {SETTINGS_KEY, initStorage} from '../../common/settings';
+
 
 class PpdnsBackground {
   constructor() {
@@ -11,6 +12,14 @@ class PpdnsBackground {
     this.getVersion().finally(() => {
       console.info('Extension version detected: ' + this.version);
     });
+
+    this.initStorage();
+  }
+
+  initStorage() {
+    if (!!chrome.storage.local.get(SETTINGS_KEY)){
+      initStorage(chrome.storage.local);
+    }
   }
 
   async getVersion() {

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -37,7 +37,7 @@ class PpdnsBackground {
           this.version = (await browser.management.getSelf()).version;
         } catch (error) {
           console.debug('Not in a Firefox browser, or something changed.');
-          console.info('Letting the version unknown');
+          console.info('Letting the version "unknown"');
           this.version = '(unknown)';
         }
       }
@@ -105,7 +105,7 @@ class PpdnsBackground {
       typeof result.settings === 'undefined' ||
       typeof result.settings.apiKey === 'undefined'
     ) {
-      console.error('no settings in local store');
+      console.warn('no settings in local store');
       this.submitInProgress = false;
       chrome.storage.local.get(SETTINGS_KEY, this.ingestError.bind(this));
       return;
@@ -175,23 +175,24 @@ class PpdnsBackground {
         { title: 'Dismiss' },
       ],
     }, function callback(notificationId) {
+      console.info('Notification: ingestError');
       // nothing necessary here, but required before Chrome 42
     });
 
     chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {
-      console.info('Button clicked: [%s] %s', notificationId, buttonIndex);
+      console.debug('Button clicked: [%s] %s', notificationId, buttonIndex);
 
       let currentSnoozedUntil = (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil;
-      console.info('Current "snoozedUntil": %s', currentSnoozedUntil);
+      console.debug('Current "snoozedUntil": %s', currentSnoozedUntil);
 
       let snoozedUntil = (Date.now() + 86400000).toString(); // now + 1 day
       await updateStorageField(chrome.storage.local, SETTINGS_KEY, 'snoozedUntil', snoozedUntil)
 
-      console.info('Snoozed until %s', (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil);
+      console.debug('Snoozed until %s', (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil);
     });
 
     chrome.notifications.onClicked.addListener(async (notificationId) => {
-      console.info('Notification clicked: %s', notificationId);
+      console.debug('Notification clicked: %s', notificationId);
       // TODO: Open some detail page onClicked of notification
     });
   }

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -16,9 +16,9 @@ class PpdnsBackground {
     this.initStorage();
   }
 
-  initStorage() {
+  async initStorage() {
     if (!!chrome.storage.local.get(SETTINGS_KEY)){
-      initStorage(chrome.storage.local);
+      await initStorage(chrome.storage.local);
     }
   }
 
@@ -150,14 +150,8 @@ class PpdnsBackground {
       });
   }
 
-  ingestError(result) {
-    chrome.storage.local.set({
-      settings: {
-        apiKey: result.settings.apiKey,
-        ingestSuccess: 'false',
-        resolutionsSubmittedCount: result.settings.resolutionsSubmittedCount,
-      },
-    });
+  async ingestError(result) {
+    await updateStorageField(chrome.storage.local, SETTINGS_KEY, 'ingestSuccess', 'false');
     chrome.notifications.create('ingestError', {
       type: 'basic',
       iconUrl: 'icon-34.png',
@@ -177,13 +171,13 @@ class PpdnsBackground {
     chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {
       console.info('Button clicked: [%s] %s', notificationId, buttonIndex);
 
-      let currentSnoozedUntil = (await chrome.storage.local.get(SETTINGS_KEY)).snoozedUntil;
+      let currentSnoozedUntil = (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil;
       console.info('Current "snoozedUntil": %s', currentSnoozedUntil);
 
       let snoozedUntil = (Date.now() + 86400000).toString(); // now + 1 day
       await updateStorageField(chrome.storage.local, SETTINGS_KEY, 'snoozedUntil', snoozedUntil)
 
-      console.info('Snoozed until %s', (await chrome.storage.local.get(SETTINGS_KEY)).snoozedUntil);
+      console.info('Snoozed until %s', (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil);
     });
 
     chrome.notifications.onClicked.addListener(async (notificationId) => {

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -163,7 +163,9 @@ class PpdnsBackground {
       iconUrl: 'icon-34.png',
       title: 'Error submitting data',
       message: 'There was an issue submitting data.',
+      contextMessage: 'PolySwarm Extension',
       priority: 2,
+      silent: true,
     });
   }
 

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -107,12 +107,14 @@ class PpdnsBackground {
     ) {
       console.error('no settings in local store');
       this.submitInProgress = false;
+      chrome.storage.local.get(SETTINGS_KEY, this.ingestError.bind(this));
       return;
     }
     let apiKey = result.settings ? result.settings.apiKey : '';
     if (apiKey === undefined || apiKey == '') {
       console.error('failed to get API key from local storage');
       this.submitInProgress = false;
+      chrome.storage.local.get(SETTINGS_KEY, this.ingestError.bind(this));
       return;
     }
 

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -152,6 +152,14 @@ class PpdnsBackground {
 
   async ingestError(result) {
     await updateStorageField(chrome.storage.local, SETTINGS_KEY, 'ingestSuccess', 'false');
+
+    const snoozedUntil = (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil;
+    if (Number(snoozedUntil) >= Date.now()){
+      // Snoozed.
+      console.info('Notification: ingestError [snoozed until %s]', snoozedUntil);
+      return
+    }
+
     chrome.notifications.create('ingestError', {
       type: 'basic',
       iconUrl: 'icon-34.png',


### PR DESCRIPTION
- Adds a "Snooze until tomorrow" button and a "Dismiss" button to the error notifications
- Adds a title that mentions PolySwarm to the notifications
- Initializes the local storage on serviceworker start, that occur earlier than popup show.

_(CI is red because unrelated stuff, tracked on PR #39)_