### PR TITLE
[5699] Fix localstorage previous settings detection

### DIFF
--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -17,7 +17,7 @@ class PpdnsBackground {
   }
 
   async initStorage() {
-    if (!!chrome.storage.local.get(SETTINGS_KEY)){
+    if (Object.keys(chrome.storage.local.get(SETTINGS_KEY)).length == 0){
       await initStorage(chrome.storage.local);
     }
   }

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -207,14 +207,8 @@ class PpdnsBackground {
       count += this.ppdnsBatchSize;
     }
 
-    chrome.storage.local.set({
-      settings: {
-        apiKey: result.settings.apiKey,
-        ingestSuccess: 'true',
-        resolutionsSubmittedCount: count.toString(),
-        snoozedUntil: 0,
-      },
-    });
+    updateStorageField(chrome.storage.local, SETTINGS_KEY, ingestSuccess, 'true');
+    updateStorageField(chrome.storage.local, SETTINGS_KEY, resolutionsSubmittedCount, count.toString());
   }
 }
 


### PR DESCRIPTION
Fixes a broken detection of previous settings, always resolving to "there is no old settings".

Also updates some old code to make harder to get past settings overwritten by mistake.