### PR TITLE
[FIX] No settings override

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ default:
     - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_SHA
     - docker push $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_REF_SLUG
     - docker run
-      -e POLYSWARM_API_URL -e BATCH_SIZE -e APPLICATION=build
+      -e POLYSWARM_API_URL -e BATCH_SIZE -e NODE_ENV -e APPLICATION=build
       -v $PWD/dist:/usr/src/app/dist:rw
       $REPO_URL/$BASE_IMAGE_NAME:$CI_COMMIT_REF_SLUG
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,3 +75,5 @@ build-prod:
     POLYSWARM_API_URL: https://api.polyswarm.network
     BATCH_SIZE: 10
     NODE_ENV: production
+  only:
+    - prod

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,4 +73,5 @@ build-prod:
   extends: .BUILD
   variables:
     POLYSWARM_API_URL: https://api.polyswarm.network
+    BATCH_SIZE: 10
     NODE_ENV: production

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ ENV REACT_APP_URL=http://portal-frontend-e2e:8080 \
 
 RUN echo "http://dl-cdn.alpinelinux.org/alpine/v3.17/main" >> /etc/apk/repositories \
   && apk upgrade -U -a \
-  && apk add --no-cache chromium curl \
+  && apk add --no-cache chromium curl xvfb \
   && apk add --no-cache build-base bash \
   && apk add --no-cache python3 py3-pip
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppdns-chrome-extension",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "",
   "license": "MIT",
   "repository": {

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -8,6 +8,8 @@ export const INITIAL_VALUE = {
   snoozedUntil: '0',
 };
 
+export const isFirefox = typeof InstallTrigger !== 'undefined';
+
 export const useSettingsStore = createChromeStorageStateHookLocal(
   SETTINGS_KEY,
   INITIAL_VALUE
@@ -18,7 +20,7 @@ export const initStorage = async (storage) => {
   if (isStorageEmpty(storage_map)){
     let storage_map = {};  // May still be "undefined" on Firefox
     storage_map[SETTINGS_KEY] = INITIAL_VALUE;
-    await storage.set(storage_map);
+    await storage.set(storage_map).then(res => console.debug('Initialized %s: %s', SETTINGS_KEY, res));
   }
 };
 

--- a/src/common/settings.js
+++ b/src/common/settings.js
@@ -14,8 +14,9 @@ export const useSettingsStore = createChromeStorageStateHookLocal(
 );
 
 export const initStorage = async (storage) => {
-  if (Object.keys(await storage.get(SETTINGS_KEY).length == 0)){
-    let storage_map = {};
+  let storage_map = await storage.get(SETTINGS_KEY);
+  if (isStorageEmpty(storage_map)){
+    let storage_map = {};  // May still be "undefined" on Firefox
     storage_map[SETTINGS_KEY] = INITIAL_VALUE;
     await storage.set(storage_map);
   }
@@ -25,11 +26,20 @@ export const updateStorageField = async (storage, key, field, value) => {
   console.debug('Updating the local storage with: %s.%s = %s', key, field, value);
 
   let storage_map = await storage.get(key);
-  if (Object.keys(storage_map).length == 0){
+  if (isStorageEmpty(storage_map)){
     console.info('Storage key "%s" found empty. Initializing with default data', key);
     await initStorage(storage);
     storage_map = await storage.get(key);
   }
   storage_map[key][field] = value;
   return await storage.set(storage_map)
+};
+
+export const isStorageEmpty = (storage_map) => {
+  // Empty values: on Firefox => undefined; on Chrome => {};
+  if (typeof storage_map == 'undefined' || Object.keys(storage_map).length == 0){
+    return true
+  } else {
+    return false
+  }
 };

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -181,6 +181,10 @@ class PpdnsBackground {
 
     chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {
       console.debug('Button clicked: [%s] %s', notificationId, buttonIndex);
+      if (notificationId != 'ingestError' || buttonIndex != 1){
+        console.debug('No action for button %1 click on notification %s', buttonIndex, notificationId);
+        return
+      }
 
       let currentSnoozedUntil = (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil;
       console.debug('Current "snoozedUntil": %s', currentSnoozedUntil);

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -1,9 +1,16 @@
 import debounce from 'lodash.debounce';
-import {SETTINGS_KEY, initStorage, updateStorageField} from '../../common/settings';
+import {SETTINGS_KEY, initStorage, updateStorageField, isStorageEmpty, isFirefox} from '../../common/settings';
 
 
 class PpdnsBackground {
   constructor() {
+    // Use the Firefox API in Chrome
+    if (isFirefox){
+      this.storage = browser.storage.local;
+    }else{
+      this.storage = chrome.storage.local;
+    }
+
     this.ppdnsL = new Map();
     this.ppdnsBatchSize = parseInt(process.env.BATCH_SIZE);
     this.submitInProgress = false;
@@ -17,8 +24,9 @@ class PpdnsBackground {
   }
 
   async initStorage() {
-    if (Object.keys(chrome.storage.local.get(SETTINGS_KEY)).length == 0){
-      await initStorage(chrome.storage.local);
+    let storage_map = await this.storage.get(SETTINGS_KEY);
+    if (isStorageEmpty(storage_map)){
+      await initStorage(this.storage);
     }
   }
 
@@ -89,7 +97,7 @@ class PpdnsBackground {
   submitPpdnsBatch() {
     /* TODO ttl on ppdns resolutions ... there are alot of same IPs and this is rather high volume, almost want a bloom ttl */
     /* todo throw error on API key fail */
-    chrome.storage.local.get(SETTINGS_KEY, this.cbX.bind(this));
+    this.storage.get(SETTINGS_KEY, this.cbX.bind(this));
   }
 
   cbX(result) {
@@ -107,14 +115,14 @@ class PpdnsBackground {
     ) {
       console.warn('no settings in local store');
       this.submitInProgress = false;
-      chrome.storage.local.get(SETTINGS_KEY, this.ingestError.bind(this));
+      this.storage.get(SETTINGS_KEY, this.ingestError.bind(this));
       return;
     }
     let apiKey = result.settings ? result.settings.apiKey : '';
     if (apiKey === undefined || apiKey == '') {
       console.error('failed to get API key from local storage');
       this.submitInProgress = false;
-      chrome.storage.local.get(SETTINGS_KEY, this.ingestError.bind(this));
+      this.storage.get(SETTINGS_KEY, this.ingestError.bind(this));
       return;
     }
 
@@ -133,19 +141,19 @@ class PpdnsBackground {
       .then((response) => response.json())
       .then((data) => {
         if (data['status'] == 'OK') {
-          chrome.storage.local.get(
+          this.storage.get(
             SETTINGS_KEY,
             this.incrementResolutionCount.bind(this)
           );
         } else {
           // key is valid, but likely lacks requried features
-          chrome.storage.local.get(SETTINGS_KEY, this.ingestError.bind(this));
+          this.storage.get(SETTINGS_KEY, this.ingestError.bind(this));
           console.error('Recieved unexpected response:', data);
         }
       })
       .catch((error) => {
         console.error('Error making request:', error);
-        chrome.storage.local.get(SETTINGS_KEY, this.ingestError.bind(this));
+        this.storage.get(SETTINGS_KEY, this.ingestError.bind(this));
       })
       .finally(() => {
         this.submitInProgress = false;
@@ -153,16 +161,16 @@ class PpdnsBackground {
   }
 
   async ingestError(result) {
-    await updateStorageField(chrome.storage.local, SETTINGS_KEY, 'ingestSuccess', 'false');
+    await updateStorageField(this.storage, SETTINGS_KEY, 'ingestSuccess', 'false');
 
-    const snoozedUntil = (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil;
+    const snoozedUntil = (await this.storage.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil;
     if (Number(snoozedUntil) >= Date.now()){
       // Snoozed.
       console.info('Notification: ingestError [snoozed until %s]', snoozedUntil);
       return
     }
 
-    chrome.notifications.create('ingestError', {
+    let notificationOptions = {
       type: 'basic',
       iconUrl: 'icon-34.png',
       title: 'Error submitting data',
@@ -174,31 +182,40 @@ class PpdnsBackground {
         { title: 'Snooze until tomorrow' },
         { title: 'Dismiss' },
       ],
-    }, function callback(notificationId) {
+    }
+    if (isFirefox){
+      delete notificationOptions.silent;
+      delete notificationOptions.buttons;
+    }
+
+    chrome.notifications.create('ingestError', notificationOptions, function callback(notificationId) {
       console.info('Notification: ingestError');
       // nothing necessary here, but required before Chrome 42
-    });
-
-    chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {
-      console.debug('Button clicked: [%s] %s', notificationId, buttonIndex);
-      if (notificationId != 'ingestError' || buttonIndex != 1){
-        console.debug('No action for button %1 click on notification %s', buttonIndex, notificationId);
-        return
-      }
-
-      let currentSnoozedUntil = (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil;
-      console.debug('Current "snoozedUntil": %s', currentSnoozedUntil);
-
-      let snoozedUntil = (Date.now() + 86400000).toString(); // now + 1 day
-      await updateStorageField(chrome.storage.local, SETTINGS_KEY, 'snoozedUntil', snoozedUntil)
-
-      console.debug('Snoozed until %s', (await chrome.storage.local.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil);
     });
 
     chrome.notifications.onClicked.addListener(async (notificationId) => {
       console.debug('Notification clicked: %s', notificationId);
       // TODO: Open some detail page onClicked of notification
     });
+
+    // Firefox accepts no buttons on notifications. Too bad for it.
+    if (!isFirefox){
+      chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {
+        console.debug('Button clicked: [%s] %s', notificationId, buttonIndex);
+        if (notificationId != 'ingestError' || buttonIndex != 0){
+          console.debug('No action for button %s click on notification %s', buttonIndex, notificationId);
+          return
+        }
+
+        let currentSnoozedUntil = (await this.storage.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil;
+        console.debug('Current "snoozedUntil": %s', currentSnoozedUntil);
+
+        let snoozedUntil = (Date.now() + 86400000).toString(); // now + 1 day
+        await updateStorageField(this.storage, SETTINGS_KEY, 'snoozedUntil', snoozedUntil)
+
+        console.debug('Snoozed until %s', (await this.storage.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil);
+      });
+    }
   }
 
   incrementResolutionCount(result) {
@@ -211,8 +228,8 @@ class PpdnsBackground {
       count += this.ppdnsBatchSize;
     }
 
-    updateStorageField(chrome.storage.local, SETTINGS_KEY, ingestSuccess, 'true');
-    updateStorageField(chrome.storage.local, SETTINGS_KEY, resolutionsSubmittedCount, count.toString());
+    updateStorageField(this.storage, SETTINGS_KEY, ingestSuccess, 'true');
+    updateStorageField(this.storage, SETTINGS_KEY, resolutionsSubmittedCount, count.toString());
   }
 }
 

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -163,7 +163,7 @@ class PpdnsBackground {
   async ingestError(result) {
     await updateStorageField(this.storage, SETTINGS_KEY, 'ingestSuccess', 'false');
 
-    const snoozedUntil = (await this.storage.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil;
+    let snoozedUntil = (await this.storage.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil;
     if (Number(snoozedUntil) >= Date.now()){
       // Snoozed.
       console.info('Notification: ingestError [snoozed until %s]', snoozedUntil);
@@ -217,9 +217,15 @@ class PpdnsBackground {
         let snoozedUntil = (Date.now() + 86400000).toString(); // now + 1 day
         await updateStorageField(this.storage, SETTINGS_KEY, 'snoozedUntil', snoozedUntil)
 
-        console.debug('Snoozed until %s', (await this.storage.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil);
+        console.debug('Snoozed until %s [now + 1day]', (await this.storage.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil);
       });
     }
+
+    // Snooze notifications for 5 min at least, even with no clicks.
+    console.debug('Current "snoozedUntil": %s', snoozedUntil);
+    snoozedUntil = (Date.now() + 300*1000).toString(); // now + 5 minutes
+    await updateStorageField(this.storage, SETTINGS_KEY, 'snoozedUntil', snoozedUntil)
+    console.debug('Snoozed until %s [now + 5min]', (await this.storage.get(SETTINGS_KEY))[SETTINGS_KEY].snoozedUntil);
   }
 
   incrementResolutionCount(result) {

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -17,7 +17,7 @@ class PpdnsBackground {
   }
 
   async initStorage() {
-    if (!!chrome.storage.local.get(SETTINGS_KEY)){
+    if (Object.keys(chrome.storage.local.get(SETTINGS_KEY)).length == 0){
       await initStorage(chrome.storage.local);
     }
   }

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -174,7 +174,7 @@ class PpdnsBackground {
       type: 'basic',
       iconUrl: 'icon-34.png',
       title: 'Error submitting data',
-      message: 'Consider to check your API Key in the PolySwarm website.',
+      message: 'Check that you entered your API Key correctly from your account settings at polyswarm.network/account/api-keys\n\xa0\nClick here to open in a new tab',
       contextMessage: 'PolySwarm Extension',
       priority: 2,
       silent: true,
@@ -193,10 +193,14 @@ class PpdnsBackground {
       // nothing necessary here, but required before Chrome 42
     });
 
-    chrome.notifications.onClicked.addListener(async (notificationId) => {
-      console.debug('Notification clicked: %s', notificationId);
-      // TODO: Open some detail page onClicked of notification
-    });
+    if (!chrome.notifications.onClicked.hasListeners()){
+      chrome.notifications.onClicked.addListener(async (notificationId) => {
+        console.debug('Notification clicked: %s', notificationId);
+        await chrome.tabs.create({ url: 'https://polyswarm.network/account/api-keys' }).then(
+          tab => { console.info('Tab opened in Polyswarm website: %s', tab); }
+        );
+      });
+    }
 
     // Firefox accepts no buttons on notifications. Too bad for it.
     if (!isFirefox){

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -203,7 +203,7 @@ class PpdnsBackground {
     }
 
     // Firefox accepts no buttons on notifications. Too bad for it.
-    if (!isFirefox){
+    if (!isFirefox && chrome.notifications.onButtonClicked.hasListeners()){
       chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {
         console.debug('Button clicked: [%s] %s', notificationId, buttonIndex);
         if (notificationId != 'ingestError' || buttonIndex != 0){

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -207,14 +207,8 @@ class PpdnsBackground {
       count += this.ppdnsBatchSize;
     }
 
-    chrome.storage.local.set({
-      settings: {
-        apiKey: result.settings.apiKey,
-        ingestSuccess: 'true',
-        resolutionsSubmittedCount: count.toString(),
-        snoozedUntil: 0,
-      },
-    });
+    updateStorageField(chrome.storage.local, SETTINGS_KEY, ingestSuccess, 'true');
+    updateStorageField(chrome.storage.local, SETTINGS_KEY, resolutionsSubmittedCount, count.toString());
   }
 }
 

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -174,7 +174,7 @@ class PpdnsBackground {
       type: 'basic',
       iconUrl: 'icon-34.png',
       title: 'Error submitting data',
-      message: 'There was an issue submitting data.',
+      message: 'Consider to check your API Key in the PolySwarm website.',
       contextMessage: 'PolySwarm Extension',
       priority: 2,
       silent: true,

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -228,8 +228,8 @@ class PpdnsBackground {
       count += this.ppdnsBatchSize;
     }
 
-    updateStorageField(this.storage, SETTINGS_KEY, ingestSuccess, 'true');
-    updateStorageField(this.storage, SETTINGS_KEY, resolutionsSubmittedCount, count.toString());
+    updateStorageField(this.storage, SETTINGS_KEY, 'ingestSuccess', 'true');
+    updateStorageField(this.storage, SETTINGS_KEY, 'resolutionsSubmittedCount', count.toString());
   }
 }
 

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -203,7 +203,7 @@ class PpdnsBackground {
     }
 
     // Firefox accepts no buttons on notifications. Too bad for it.
-    if (!isFirefox && chrome.notifications.onButtonClicked.hasListeners()){
+    if (!isFirefox && !chrome.notifications.onButtonClicked.hasListeners()){
       chrome.notifications.onButtonClicked.addListener(async (notificationId, buttonIndex) => {
         console.debug('Button clicked: [%s] %s', notificationId, buttonIndex);
         if (notificationId != 'ingestError' || buttonIndex != 0){


### PR DESCRIPTION
Do not override localstorage settings by accident.

Also add helpers to handle subtle differences between Firefox and Chrome implementation of local storage for extensions.