### PR TITLE
Bump version -> `1.1.7`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ppdns-chrome-extension",
-  "version": "1.1.4",
+  "version": "1.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ppdns-chrome-extension",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "description": "",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
https://github.com/polyswarm/ppdns-chrome-extension/pull/49#pullrequestreview-2352366326
> looks good to me. we should bump the version (minor/patch?) and then I think we can submit to the browser stores

As asked, this PR bumps the version.