### PR TITLE
[FIX] Only show an error on the popup after one day trying

### DIFF
--- a/src/pages/Popup/Popup.jsx
+++ b/src/pages/Popup/Popup.jsx
@@ -78,7 +78,9 @@ const Popup = () => {
 
           {settings.apiKey &&
             settings.apiKey.length &&
-            settings.ingestSuccess == 'false' && (
+            settings.ingestSuccess == 'false' &&
+            settings.apiKeyCheckedDate != '0' &&
+            getLastSuccessString(settings) != 'today' &&(
               <div className="ingest-failure">
                 There was an issue submitting data. Have you joined the{' '}
                 <a


### PR DESCRIPTION
This makes the error message of the popup to show up only if the API Key was already checked as valid AND the submission failed for a whole day.