### PR TITLE
[FIX] Do not bother the user with API Key errors newer than 1 day

### DIFF
--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -195,6 +195,13 @@ class PpdnsBackground {
       return
     }
 
+    let lastSuccess = await this.getLastSuccessString();
+    if (lastSuccess === 'today') {
+      // May be an intermitent issue. Do not bother the user.
+      console.info('Notification: %s [snoozed: last success %s]', errorname, lastSuccess);
+      return
+    }
+
     let message = ('Your telemetry data will be saved locally until you enter an API Key from your account settings.'
     + '\n\xa0\nClick here to open polyswarm.network/account/api-keys in a new tab');
 

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -127,7 +127,7 @@ class PpdnsBackground {
     if (apiKey === undefined || apiKey == '') {
       console.error('failed to get API key from local storage');
       this.submitInProgress = false;
-      this.storage.get(SETTINGS_KEY, this.ingestError.bind(this));
+      this.storage.get(SETTINGS_KEY, this.apikeyError.bind(this));
       return;
     }
 


### PR DESCRIPTION
Is hard to distinguish 40X errors _right now_. Do not bother the user with API Key errors if it somehow worked in the past 24h.