### PR TITLE
Revert "build in dind": CI started to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,9 +29,7 @@ default:
 .BUILD:
   stage: build
   tags:
-    - stage-kube-newer
-  variables:
-    DOCKER_HOST: tcp://dind-dind.ci.svc.cluster.local:2376
+    - kube-new
   script:
     # try to download the multi-stage dependant image and retag it as latest
     - e2e dependencies docker/Dockerfile


### PR DESCRIPTION
This reverts commit 74a51afa3d21cefddfc9ecff630a478978fbf6a3.